### PR TITLE
ブランチポリシーテンプレートの名前を "protect main branch" に変更

### DIFF
--- a/.github/branch-policy-template.json
+++ b/.github/branch-policy-template.json
@@ -1,5 +1,5 @@
 {
-  "name": "branch-policy-template",
+  "name": "protect main branch",
   "target": "branch",
   "enforcement": "active",
   "conditions": {


### PR DESCRIPTION
## 変更内容

`.github/branch-policy-template.json` の `name` プロパティを `"branch-policy-template"` から `"protect main branch"` に変更しました。

インポート時に意味のある名前で登録されるようになります。

Closes #69